### PR TITLE
[WIP] MLOPS-114: Add OAuth2-proxy and Ambassador Auth Service

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -140,3 +140,22 @@ module "seldon" {
   source    = "./modules/seldon"
   namespace = kubernetes_namespace.seldon_namespace[0].metadata[0].name
 }
+
+resource "kubernetes_namespace" "oauth2-proxy-namespace" {
+  count = var.install_oauth2_proxy ? 1 : 0
+  metadata {
+    name = "oauth2-proxy"
+  }
+}
+
+module "oauth2-proxy" {
+  count = var.install_oauth2_proxy ? 1 : 0
+  source = "./modules/oauth2-proxy"
+  namespace = kubernetes_namespace.oauth2-proxy-namespace.metadata[0].name
+  domain = ""
+  oauth_client_id = ""
+  oauth_client_secret = ""
+  oauth_cookie_secret = ""
+  oauth_provider = ""
+  redirect_url = ""
+}

--- a/modules/oauth2-proxy/README.md
+++ b/modules/oauth2-proxy/README.md
@@ -1,0 +1,3 @@
+# OAUTH 2.0 Proxy
+
+This module provisions OAuth 2.0 Proxy

--- a/modules/oauth2-proxy/main.tf
+++ b/modules/oauth2-proxy/main.tf
@@ -1,0 +1,30 @@
+data "template_file" "oauth2-proxy_values" {
+  template = file("${path.module}/templates/oauth2-proxy.yaml")
+  vars = {
+    oauth_image_repository = var.oauth_image_repository
+    oauth_image_tag        = var.oauth_image_tag
+
+    oauth_client_id     = var.oauth_client_id
+    oauth_client_secret = var.oauth_client_secret
+    oauth_provider      = var.oauth_provider
+
+    oauth_cookie_secret = var.oauth_cookie_secret
+    oauth_cookie_expire = var.oauth_cookie_expire
+
+    redirect_url = var.redirect_url
+    domain = var.domain
+  }
+}
+
+resource "helm_release" "oauth2-proxy" {
+  name          = "oauth2-proxy"
+  repository    = "https://k8s-at-home.com/charts/"
+  chart         = "oauth2-proxy"
+  version       = var.oauth_helm_chart_version
+  namespace     = var.namespace
+  recreate_pods = "true"
+
+  values = [
+    data.template_file.oauth2-proxy_values.rendered
+  ]
+}

--- a/modules/oauth2-proxy/templates/oauth2-proxy.yaml
+++ b/modules/oauth2-proxy/templates/oauth2-proxy.yaml
@@ -1,0 +1,51 @@
+fullnameOverride: oauth2-proxy
+ 
+image:
+  repository: ${oauth_image_repository}
+  tag: ${oauth_image_tag}
+ 
+config:
+  clientID: "${oauth_client_id}"
+  clientSecret: "${oauth_client_secret}"
+  cookieSecret: "${oauth_cookie_secret}"
+  configFile: |
+    provider = "${oauth_provider}"
+    email_domains = "*"
+    redirect-url = "${redirect_url}"
+    http-address = 0.0.0.0:4180
+    pass-authorization-header = false
+    cookie-secure = false
+    cookie-domain = "${domain}"
+    whitelist-domain = "${domain}"
+    reverse-proxy = true
+
+ingress:
+  enabled: false
+
+service:
+  annotations:
+    getambassador.io/config: |
+      ---
+      apiVersion: getambassador.io/v2
+      kind: AuthService
+      name: authentication
+      auth_service: "http://oauth2-proxy.oauth2-proxy:4180"
+      path_prefix: "/oauth2/start?rd="
+      proto: http
+      ---
+      apiVersion: getambassador.io/v2
+      kind:  Mapping
+      name:  oauth2_proxy_mapping
+      prefix: "/oauth2/"
+      service: http://oauth2-proxy.oauth2-proxy:4180/
+      rewrite: "/oauth2/"
+      bypass_auth: true
+  port: 4180
+ 
+resources:
+  limits:
+    cpu: 200m
+    memory: 256Mi
+  requests:
+    cpu: 200m
+    memory: 128Mi

--- a/modules/oauth2-proxy/variables.tf
+++ b/modules/oauth2-proxy/variables.tf
@@ -1,0 +1,43 @@
+
+variable "oauth_client_id" {
+  description = "OAuth 2 Client ID"
+}
+variable "oauth_client_secret" {
+  description = "OAuth 2 Client Secret"
+}
+variable "oauth_provider" {
+  description = "OAuth 2 Provider"
+}
+variable "redirect_url" {
+  description = "OAuth 2 Redirect URL"
+}
+variable "domain" {
+  description = "Application domain"
+}
+
+# OAuth2_proxy configuration
+variable "oauth_helm_chart_version" {
+  description = "OAuth 2.0 Helm Chart Version"
+  default     = "4.3.0"
+}
+variable "oauth_image_repository" {
+  default     = "quay.io/pusher/oauth2_proxy"
+  description = "image repository of oauth2 proxy"
+}
+variable "oauth_image_tag" {
+  default     = "v5.1.0"
+  description = "image tag of oauth2 proxy"
+}
+# OAuth2_proxy cookie configuration
+variable "oauth_cookie_expire" {
+  default     = "3600"
+  description = "TTL for issuing cookies by oauth2_proxy"
+}
+variable "oauth_cookie_secret" {
+  description = "Secret for issuing cookies by oauth2_proxy"
+}
+
+variable "namespace" {
+  description = "Namespace name to deploy the application"
+  default     = "default"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -179,3 +179,25 @@ variable "seldon_namespace" {
   default = "seldon"
 }
 
+## OAuth-2-Proxy
+variable "install_oauth2_proxy" {
+  default = false
+}
+variable "oauth_client_id" {
+  description = "OAuth 2 Client ID"
+}
+variable "oauth_client_secret" {
+  description = "OAuth 2 Client Secret"
+}
+variable "oauth_provider" {
+  description = "OAuth 2 Provider"
+}
+variable "redirect_url" {
+  description = "OAuth 2 Redirect URL"
+}
+variable "domain" {
+  description = "Application domain"
+}
+variable "oauth_cookie_secret" {
+  description = "Secret for issuing cookies by oauth2_proxy"
+}


### PR DESCRIPTION
This is not working yet.
The authentication flow works and securing an endpoint also, but the Cookie is not being set correctly. Although it might work, feels a lot like a hack and doesn't give us a lot of flexibility like Roles, Read / Write access, which defeats the purpose of using an API Gateway.
I'll start trying ORY and see if it integrates nicer and come back later to try to fix this

Also, needs to move away from HELM to plain terraform