### PR TITLE
[DO NOT MERGE] MLOPS-201: Update Authentication Rules

### DIFF
--- a/modules/ory/oathkeeper/access-rule-oathkeeper.yaml
+++ b/modules/ory/oathkeeper/access-rule-oathkeeper.yaml
@@ -13,15 +13,31 @@
   credentials_issuer:
     handler: noop
 
-- id: seldon-access-rule
+# --- SELDON
+- # TODO: Admin Only - Add Authorization
+- id: seldon-access-rule:private
   match:
     url: <{http,https}>://${hostname}/seldon/<**>
     methods:
-      - GET
       - POST
       - PUT
       - DELETE
       - PATCH
+  authenticators:
+    - handler: bearer_token
+    - handler: cookie_session
+  authorizer:
+    handler: allow
+  mutators:
+    - handler: id_token
+  credentials_issuer:
+    handler: noop
+
+- id: seldon-access-rule:public
+  match:
+    url: <{http,https}>://${hostname}/seldon/<**>
+    methods:
+      - GET
   authenticators:
     - handler: anonymous
   authorizer:
@@ -31,6 +47,7 @@
   credentials_issuer:
     handler: noop
 
+# --- MLFLOW
 - id: mlflow-access-rule
   match:
     url: <{http,https}>://mlflow.${hostname}/<**>
@@ -41,14 +58,15 @@
       - DELETE
       - PATCH
   authenticators:
-    - handler: anonymous
+    - handler: cookie_session
   authorizer:
     handler: allow
   mutators:
-    - handler: noop
+    - handler: id_token
   credentials_issuer:
     handler: noop
 
+# --- JUPYTERHUB
 - id: jhub-access-rule
   match:
     url: <{http,https}>://jupyter.${hostname}/<**>
@@ -59,15 +77,16 @@
       - DELETE
       - PATCH
   authenticators:
-    - handler: noop
+    - handler: cookie_session
   authorizer:
     handler: allow
   mutators:
-    - handler: noop
+    - handler: id_token
   credentials_issuer:
     handler: noop
 
-- id: prefect-access-rule
+# --- PREFECT
+- id: prefect-access-rule:ui
   match:
     url: <{http,https}>://prefect.${hostname}/<**>
     methods:
@@ -77,14 +96,17 @@
       - DELETE
       - PATCH
   authenticators:
-    - handler: anonymous
+    - handler: bearer_token
+    - handler: cookie_session
   authorizer:
     handler: allow
   mutators:
-    - handler: noop
+    - handler: id_token
   credentials_issuer:
     handler: noop
 
+# --- ORY KRATOS
+# PUBLIC ENDPOINTS TO ALLOW VERIFYING TOKEN AND REGISTERING FROM CLI
 - id: ory:kratos:public
   upstream:
     preserve_host: true
@@ -104,6 +126,7 @@
   mutators:
     - handler: noop
 
+# --- ORY KRATOS UI
 - id: ory-kratos-ui:anonymous
   upstream:
     preserve_host: true


### PR DESCRIPTION
Updates authentication rules to all services. Once applied, the services will need authentication to be used.

There are two authenticators set up:
- bearer_token: Deal with programatic access. Expects a bearer token and validates it against a ORY secrets
- cookie_session: Deal with Browser based access. Expects a Session Cookie with a token and validates it in the same way as above.

In both cases, after getting the token, the gateway validates the user and re-encodes the user information into a JWT token (This is configured by the id_token mutator.

There can be more than one authenticators, but they are tried in a top-down approach. If the first fails, the second one is tried. If both fail, it returns a 401.

TODO: Add Authorization to differentiate regular users from Admins