### PR TITLE
bugfix when removing feast_spark_operator_prefect_crb

### DIFF
--- a/modules/prefect-server/main.tf
+++ b/modules/prefect-server/main.tf
@@ -134,6 +134,8 @@ resource "kubernetes_cluster_role_binding" "seldon_prefect_crb" {
 }
 
 resource "kubernetes_cluster_role_binding" "feast_spark_operator_prefect_crb" {
+  count = var.feast_spark_operator_cluster_role_name != "" ? 1 : 0
+
   metadata {
     name = "prefect-feast-spark-operator"
   }


### PR DESCRIPTION
do not install Spark cluster role binding in Prefect when Feast is not installed.