### PR TITLE
Remove HTTP from seldon storageInitializer image

### DIFF
--- a/modules/seldon/values.yaml
+++ b/modules/seldon/values.yaml
@@ -1,4 +1,4 @@
 storageInitializer:
-  image: "http://gcr.io/kfserving/storage-initializer:v0.4.0"
+  image: "gcr.io/kfserving/storage-initializer:v0.4.0"
 usageMetrics:
   enabled: ${usage_metrics_enabled}


### PR DESCRIPTION
Seldon `storageInitializer` image name cannot contain the HTTP on it. This PR removes it from the image reference