### PR TITLE
add account recovery settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.0
+
+### Features
+- Support password recovery using SMTP
+
 ## 0.1.0
 
 ### Features

--- a/main.tf
+++ b/main.tf
@@ -182,6 +182,10 @@ module "ory" {
   protocol = var.protocol
 
   enable_registration = var.enable_registration_page
+  enable_password_recovery = var.enable_password_recovery
+  enable_verification = var.enable_verification
+  smtp_connection_uri = var.smtp_connection_uri
+  smtp_from_address = var.smtp_from_address
 
   access_rules_path = var.access_rules_path
 }

--- a/modules/ory/kratos/main.tf
+++ b/modules/ory/kratos/main.tf
@@ -36,6 +36,10 @@ resource "helm_release" "ory-kratos" {
       dsn = "postgres://${var.db_username}:${urlencode(var.db_password)}@${module.kratos-postgres.db_host}:5432/${var.database_name}",
       app_url = var.app_url,
       ui_path = local.ui_url,
+      smtp_connection_uri = var.smtp_connection_uri,
+      smtp_from_address = var.smtp_from_address,
+      enable_password_recovery = var.enable_password_recovery,
+      enable_verification = var.enable_verification,
       oidc_providers_config = templatefile("${path.module}/oidc_providers.yaml.tmpl", {
         oauth2_providers = var.oauth2_providers
         provider_paths = local.provider_paths

--- a/modules/ory/kratos/values.yaml
+++ b/modules/ory/kratos/values.yaml
@@ -34,7 +34,7 @@ kratos:
           ui_url: ${ui_path}/settings
 
         verification:
-          enabled: false
+          enabled: ${enable_verification}
           ui_url: ${ui_path}/verify
 
         logout:
@@ -57,8 +57,11 @@ kratos:
             oidc:
               hooks:
                 - hook: session
-
           ui_url: ${ui_path}/auth/registration
+
+        recovery:
+          enabled: ${enable_password_recovery}
+          ui_url: ${ui_path}/recovery
 
     log:
       level: debug
@@ -91,8 +94,8 @@ kratos:
 
     courier:
       smtp:
-        connection_uri: "smtp://omigamibot%40gmail.com:omigamidevbot2021@smtp.gmail.com:587"
-        from_address: "omigamibot@gmail.com"
+        connection_uri: ${smtp_connection_uri}
+        from_address: ${smtp_from_address}
 
   identitySchemas:
     # TODO: Make terraform render this dynamically
@@ -118,6 +121,9 @@ kratos:
                     }
                   },
                   "verification": {
+                    "via": "email"
+                  },
+                  "recovery": {
                     "via": "email"
                   }
                 }

--- a/modules/ory/kratos/variables.tf
+++ b/modules/ory/kratos/variables.tf
@@ -56,3 +56,23 @@ variable "oauth2_providers" {
   }))
   description = "OAuth2 Providers credentials"
 }
+
+variable "smtp_connection_uri" {
+  description = "SMTP Connection for Ory"
+  type = string
+}
+
+variable "smtp_from_address" {
+  description = "Email address for outgoing mails from Ory"
+  type = string
+}
+
+variable "enable_password_recovery" {
+  description = "Bool to set to enable password recovery using emails"
+  type = bool
+}
+
+variable "enable_verification" {
+  description = "Bool to set to enable account registration confirmation using emails"
+  type = bool
+}

--- a/modules/ory/main.tf
+++ b/modules/ory/main.tf
@@ -17,6 +17,10 @@ module "ory-kratos" {
   cookie_domain = var.hostname
   db_password = var.kratos_db_password
   oauth2_providers = var.oauth2_providers
+  enable_password_recovery = var.enable_password_recovery
+  enable_verification = var.enable_verification
+  smtp_connection_uri = var.smtp_connection_uri
+  smtp_from_address = var.smtp_from_address
 
   app_url = "${var.protocol}://${var.hostname}"
 }

--- a/modules/ory/variables.tf
+++ b/modules/ory/variables.tf
@@ -26,6 +26,26 @@ variable "enable_registration" {
   type = bool
 }
 
+variable "smtp_connection_uri" {
+  description = "SMTP Connection for Ory"
+  type = string
+}
+
+variable "smtp_from_address" {
+  description = "Email address for outgoing mails from Ory"
+  type = string
+}
+
+variable "enable_password_recovery" {
+  description = "Bool to set to enable password recovery using emails"
+  type = bool
+}
+
+variable "enable_verification" {
+  description = "Bool to set to enable account registration confirmation using emails"
+  type = bool
+}
+
 variable "oauth2_providers" {
   //  Configure multiple Oauth2 providers.
   //  example:

--- a/variables.tf
+++ b/variables.tf
@@ -279,6 +279,30 @@ variable "oauth2_providers" {
   description = "OAuth2 Providers credentials"
 }
 
+variable "smtp_connection_uri" {
+  description = "SMTP Connection for Ory"
+  type = string
+  default = "smtp://omigamibot%40gmail.com:omigamidevbot2021@smtp.gmail.com:587"
+}
+
+variable "smtp_from_address" {
+  description = "Email address for outgoing mails from Ory"
+  type = string
+  default = "omigamibot@gmail.com"
+}
+
+variable "enable_password_recovery" {
+  description = "Bool to set to enable password recovery using emails"
+  type = bool
+  default = false
+}
+
+variable "enable_verification" {
+  description = "Bool to set to enable account registration confirmation using emails"
+  type = bool
+  default = false
+}
+
 ## Other K8S tools
 
 variable "install_metrics_server" {

--- a/variables.tf
+++ b/variables.tf
@@ -282,13 +282,13 @@ variable "oauth2_providers" {
 variable "smtp_connection_uri" {
   description = "SMTP Connection for Ory"
   type = string
-  default = "smtp://omigamibot%40gmail.com:omigamidevbot2021@smtp.gmail.com:587"
+  default = "smtp://"
 }
 
 variable "smtp_from_address" {
   description = "Email address for outgoing mails from Ory"
   type = string
-  default = "omigamibot@gmail.com"
+  default = ""
 }
 
 variable "enable_password_recovery" {


### PR DESCRIPTION
- Add option to send password recovery using emails.
- SMTP information can be set using `smtp_connection_uri` and `smtp_from_address` vars