### PR TITLE
Enable link method in ory so kratos can send a password reset link

### DIFF
--- a/modules/ory/kratos/values.yaml
+++ b/modules/ory/kratos/values.yaml
@@ -27,6 +27,8 @@ kratos:
           config:
             providers:
               ${indent(14, oidc_providers_config)}
+        link:
+          enabled: true
 
       flows:
         settings:


### PR DESCRIPTION
This is small but needed to make the email sending out the reset link.