### PR TITLE
docs: installs sphinx automatically.

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,14 +7,21 @@ SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build
+SPHINXPATH    := $(shell command -v ${SPHINXBUILD})
+
+.PHONY: help Makefile ${SPHINXBUILD}
 
 # Put it first so that "make" without argument is like "make help".
-help:
+help: ${SPHINXBUILD}
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+# conditionally install sphinx if sphinx-build is not found in PATH
+${SPHINXBUILD}:
+ifndef SPHINXPATH
+	pip install sphinx
+endif
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
+%: Makefile ${SPHINXBUILD}
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,13 +1,9 @@
-To build the docs, install `Sphinx`:
-
-```commandline
-pip install sphinx
-```
-
-And then run this inside `docs` folder:
+To build the docs run this inside `docs` folder:
 
 ```commandline
 make html
 ```
+
+If `sphinx-build` is not in your path this will install the `sphinx` python module automatically.
 
 The documentation will be built into `_build` folder. Access it by opening `_build/index.html`. 


### PR DESCRIPTION
Adds target to docs/Makefile to check for sphinx-build and automatically pip install sphinx if it is missing.

`${SPHINXBUILD}` make target is a no-op if ${SPHINXPATH} is defined.