### PR TITLE
Fix error when accessing prefect graphql installed on a local minikube

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -106,14 +106,13 @@ module "prefect-server" {
   namespace = kubernetes_namespace.prefect_namespace.metadata[0].name
 
   parent_module_name = basename(abspath(path.module))
-  hostname = var.hostname
-  protocol = var.protocol
   service_type = var.prefect_service_type
   agent_prefect_labels = var.prefect_agent_labels
   service_account_name = var.prefect_service_account_name
   seldon_manager_cluster_role_name = var.install_seldon ? "seldon-manager-role-${var.seldon_namespace}" : ""
   feast_spark_operator_cluster_role_name = var.install_feast ? var.feast_spark_operator_cluster_role_name : ""
   create_tenant_enabled = var.prefect_create_tenant_enabled
+  graphql_url = var.install_locally ? "http://localhost:4200/graphql" : "${var.protocol}://prefect.${var.hostname}/graphql/"
 }
 
 

--- a/modules/prefect-server/main.tf
+++ b/modules/prefect-server/main.tf
@@ -84,7 +84,7 @@ resource "helm_release" "prefect-server" {
 
   set {
     name = "ui.apolloApiUrl"
-    value = "${var.protocol}://prefect.${var.hostname}/graphql/"
+    value = var.graphql_url
   }
 
   set {

--- a/modules/prefect-server/variables.tf
+++ b/modules/prefect-server/variables.tf
@@ -1,9 +1,5 @@
-variable "hostname" {
-  description = "Application hostname ex.: mlops.mywebsite.com"
-}
-
-variable "protocol" {
-  description = "Preferred connection protocol"
+variable "graphql_url" {
+  description = "URL to Apollo GraphQL"
 }
 
 variable "parent_module_name" {

--- a/tutorials/set-up-minikube-cluster.md
+++ b/tutorials/set-up-minikube-cluster.md
@@ -42,6 +42,7 @@ jhub_proxy_secret_token = "IfYouDecideToUseJhubProxyYouShouldChangeThisValueToAR
 enable_ory_authentication = false
 oauth2_providers = []
 mlflow_artifact_root = "/tmp"
+install_locally = true
 ```
 
 ## Step 4: Initialising Terraform
@@ -49,7 +50,7 @@ mlflow_artifact_root = "/tmp"
 Run the following in your shell to set your Kubectl config.
 
 ```
-export KUBE_CONFIG_PATH=~./kube/config
+export KUBE_CONFIG_PATH=~/.kube/config
 ```
 
 Now change into the `OpenMLOps` directory and run `terraform init`, which will pull down the terraform dependencies that you need.
@@ -99,7 +100,13 @@ prefect backend server && prefect server create-tenant --name default --slug def
 
 ## Trying out the services
 
-The first step is to look at the service addresses and ports available. Run the command
+You can keep the port forward from the previous step running. Or run:
+
+```
+kubectl port-forward -n prefect svc/prefect-server-apollo 4200
+```
+
+Then, look at the service addresses and ports available. Run the command:
 
 ```
 kubectl get services --all-namespaces

--- a/tutorials/set-up-minikube-cluster.md
+++ b/tutorials/set-up-minikube-cluster.md
@@ -26,6 +26,7 @@ minikube tunnel
 
 Next you'll need to personalise the secrets and other values in the tfvars file. You can create  a file in `openmlops/OpenMLOps/my_vars.tfvars` and use the example settings below.
 
+Make sure that `install_locally = true` and `aws = false` 
 
 ```
 aws = false

--- a/tutorials/set-up-open-source-production-mlops-architecture-aws.md
+++ b/tutorials/set-up-open-source-production-mlops-architecture-aws.md
@@ -94,7 +94,25 @@ Next you'll need to personalise the secrets and other values in the `openmlops/O
 
 ## Initialising Terraform
 
-Now change into the `OpenMLOps-AWS` directory and run `terraform init`, which will pull down the terraform dependencies that you need.
+### Creating an S3 bucket to store Terraform state
+
+If you don't have an S3 bucket to store Terraform state files, you can create a new one by running:
+
+```
+aws s3api create-bucket --bucket YOUR_BUCKET_NAME --region YOUR_REGION
+```
+
+### Initialising Terraform with the s3 backend
+
+Now change into the `OpenMLOps-AWS` directory and create `backend-config.txt` file with the bucket name:
+
+```
+bucket = "YOUR_BUCKET_NAME"
+key = "open-mlops.tfstate"
+region = "YOUR_REGION"
+```
+
+Then, run `terraform init -backend-config=backend-config.txt`, which will pull down the terraform dependencies that you need.
 
 You should see "Terraform has been successfully initialized!" towards the end of the output.
 

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,11 @@ variable "protocol" {
   description = "Preferred connection protocol. If using https, a valid ACM certificate must be provided under tls_certificate_arn. See documentation"
 }
 
+variable "install_locally" {
+  default = false
+  description = "Whether to install on a local minikube"
+}
+
 ## MLFlow
 
 variable "mlflow_namespace" {


### PR DESCRIPTION
See https://github.com/datarevenue-berlin/OpenMLOps/issues/92

- Add a `install_locally` boolean variable to use when install on a minikube
- When install locally, prefect GraphQL is `https://localhost:4200/graphql`