### PR TITLE
Add prefect pull image secret

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -114,6 +114,7 @@ module "prefect-server" {
   feast_spark_operator_cluster_role_name = var.install_feast ? var.feast_spark_operator_cluster_role_name : ""
   create_tenant_enabled = var.prefect_create_tenant_enabled
   graphql_url = var.install_locally ? "http://localhost:4200/graphql" : "${var.protocol}://${var.prefect_graphql_url}"
+  prefect_pull_image_auth = var.prefect_pull_image_auth
 }
 
 

--- a/modules/prefect-server/main.tf
+++ b/modules/prefect-server/main.tf
@@ -33,11 +33,6 @@ resource "helm_release" "prefect-server" {
   }
 
   set {
-    name = "imagePullSecrets"
-    value = "regcred"
-  }
-
-  set {
     name  = "prefectVersionTag"
     value = var.prefect_version_tag
   }
@@ -116,6 +111,14 @@ resource "helm_release" "prefect-server" {
       "agent" = {
         "prefectLabels" = var.agent_prefect_labels
       }
+    }),
+
+     yamlencode({
+      "imagePullSecrets" = [
+        {
+          name = "regcred"
+        }
+      ]
     }),
   ]
 }

--- a/modules/prefect-server/main.tf
+++ b/modules/prefect-server/main.tf
@@ -33,6 +33,11 @@ resource "helm_release" "prefect-server" {
   }
 
   set {
+    name = "imagePullSecrets"
+    value = "regcred"
+  }
+
+  set {
     name  = "prefectVersionTag"
     value = var.prefect_version_tag
   }
@@ -149,4 +154,25 @@ resource "kubernetes_cluster_role_binding" "feast_spark_operator_prefect_crb" {
     name = var.service_account_name
     namespace = var.namespace
   }
+}
+
+resource "kubernetes_secret" "omi_prefect_image_pull_secret" {
+  metadata {
+    name = "regcred"
+    namespace = var.namespace
+  }
+
+   data = {
+    ".dockerconfigjson" = <<-DOCKER
+          {
+            "auths": {
+              "https://index.docker.io/v1/": {
+                "auth": "${var.prefect_pull_image_auth}"
+              }
+            }
+          }
+          DOCKER
+  }
+
+  type = "kubernetes.io/dockerconfigjson"
 }

--- a/modules/prefect-server/main.tf
+++ b/modules/prefect-server/main.tf
@@ -112,14 +112,6 @@ resource "helm_release" "prefect-server" {
         "prefectLabels" = var.agent_prefect_labels
       }
     }),
-
-     yamlencode({
-      "imagePullSecrets" = [
-        {
-          name = "regcred"
-        }
-      ]
-    }),
   ]
 }
 

--- a/modules/prefect-server/variables.tf
+++ b/modules/prefect-server/variables.tf
@@ -17,6 +17,11 @@ variable "prefect_version_tag" {
   default     = "latest"
 }
 
+variable "prefect_pull_image_auth" {
+  description = "Hashed credentials from docker to use for pulling images for agent and job (flow) pods"
+  type = string
+}
+
 variable "annotations" {
   description = "Annotations to merge into all object configurations"
   default     = {}

--- a/variables.tf
+++ b/variables.tf
@@ -87,6 +87,11 @@ variable "prefect_graphql_url" {
   type = string
 }
 
+variable "prefect_pull_image_auth" {
+  description = "Hashed credentials from docker to use for pulling images for agent and job (flow) pods"
+  type = string
+}
+
 ## Jupyter Hub
 
 variable "jupyter_dummy_password" {


### PR DESCRIPTION
This will allow prefect to pull images from private repositories.
For this to work with current Prefect version though, we have to set this line `image_pull_secrets=["regcred"]` into the KubernetesRun flow config init method, because it seems like this Prefect helm chart has quite a few bugs in it.